### PR TITLE
Update api version

### DIFF
--- a/config/crd/bases/garo.tietoevry.com_githubactionrunners.yaml
+++ b/config/crd/bases/garo.tietoevry.com_githubactionrunners.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_githubactionrunners.yaml
+++ b/config/crd/patches/cainjection_in_githubactionrunners.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_githubactionrunners.yaml
+++ b/config/crd/patches/webhook_in_githubactionrunners.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: githubactionrunners.garo.tietoevry.com


### PR DESCRIPTION
Fix the following warning

```
$ helm install github-actions-runner-operator evryfs-oss/github-actions-runner-operator --namespace github-actions-runner-operator
W1118 12:21:48.585046   16641 warnings.go:67] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
```