### PR TITLE
#321: Update sample: externals mount point

### DIFF
--- a/config/samples/garo_v1alpha1_githubactionrunner.yaml
+++ b/config/samples/garo_v1alpha1_githubactionrunner.yaml
@@ -72,6 +72,8 @@ spec:
               name: runner-diag
             - mountPath: /home/runner/_work
               name: runner-work
+            - mountPath: /home/runner/externals
+              name: runner-externals
             - mountPath: /home/runner/.m2
               name: mvn-repo
             - mountPath: /home/runner/.m2/settings.xml
@@ -95,6 +97,8 @@ spec:
               name: docker-certs
             - mountPath: /home/runner/_work
               name: runner-work
+            - mountPath: /home/runner/externals
+              name: runner-externals
         - name: exporter
           image: quay.io/evryfs/github-actions-runner-metrics:v0.0.3
           ports:
@@ -109,6 +113,8 @@ spec:
           name: runner-work
         - emptyDir: {}
           name: runner-diag
+        - emptyDir: {}
+          name: runner-externals
         - emptyDir: {}
           name: mvn-repo
         - emptyDir: {}


### PR DESCRIPTION
Add new mount point to the example GithubActionRunner runner-pool kustomization to allow docker container (dind) access to the action runners `externals` directory in the runner container. This is required to stop the docker container from failing at actions/checkout with the error

```
OCI runtime exec failed: exec failed: container_linux.go:349: starting container process caused "exec: \"/__e/node12/bin/node\": stat /__e/node12/bin/node: no such file or directory": unknown
```

Refs: #321 